### PR TITLE
Switch the benchmark CI job to use the intended method for only compiling and not running the benchmarks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,4 +73,4 @@ jobs:
       uses: Swatinem/rust-cache@v2.8.0
     - name: Compile benchmarks, but do not run them
       # There are no benchmarks with "nothing" in their name, hence this command only compiles the benchmarks but does not run them.
-      run: cargo bench --all-features nothing
+      run: cargo bench --all-features --no-run


### PR DESCRIPTION
There's actually a flag for this :P